### PR TITLE
fix prefixes

### DIFF
--- a/AwesomeApp/HelloWorld.al
+++ b/AwesomeApp/HelloWorld.al
@@ -2,7 +2,7 @@
 // Remember that object names and IDs should be unique across all extensions.
 // AL snippets start with t*, like tpageext - give them a try and happy coding!
 
-pageextension 50100 CustomerListExt extends "Customer List"
+pageextension 50100 PTEACustomerListExt extends "Customer List"
 {
     trigger OnOpenPage();
     begin

--- a/BwesomeApp/HelloWorld.al
+++ b/BwesomeApp/HelloWorld.al
@@ -2,7 +2,7 @@
 // Remember that object names and IDs should be unique across all extensions.
 // AL snippets start with t*, like tpageext - give them a try and happy coding!
 
-pageextension 50111 CustomerListExt extends "Customer List"
+pageextension 50111 PTEBCustomerListExt extends "Customer List"
 {
     trigger OnOpenPage();
     begin

--- a/CwesomeApp/HelloWorld.al
+++ b/CwesomeApp/HelloWorld.al
@@ -2,7 +2,7 @@
 // Remember that object names and IDs should be unique across all extensions.
 // AL snippets start with t*, like tpageext - give them a try and happy coding!
 
-pageextension 50121 CustomerListExt extends "Customer List"
+pageextension 50121 PTECCustomerListExt extends "Customer List"
 {
     trigger OnOpenPage();
     begin


### PR DESCRIPTION
This pull request includes changes to the `HelloWorld.al` files across multiple projects to ensure unique object names and IDs by updating the page extension names.

Changes to `HelloWorld.al` files:

* [`AwesomeApp/HelloWorld.al`](diffhunk://#diff-e8bf5cb015a765b10b13be3b738daee9317be065b80d13e5253ec2304e655955L5-R5): Updated page extension name from `CustomerListExt` to `PTEACustomerListExt`.
* [`BwesomeApp/HelloWorld.al`](diffhunk://#diff-260fef8f4aefd88269f8cd746b71db182751ecc59afce962f7a8624aca369ad3L5-R5): Updated page extension name from `CustomerListExt` to `PTEBCustomerListExt`.
* [`CwesomeApp/HelloWorld.al`](diffhunk://#diff-46c8448fe8f22c03ff4165bfa5c4946af690c4a13e7997022c7901b4b0e07072L5-R5): Updated page extension name from `CustomerListExt` to `PTECCustomerListExt`.